### PR TITLE
Small improvements to CLI documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,10 @@ Now you can fetch all of your items from toggl like this:
 
     $ toggl-to-sqlite fetch toggl.db
 
+**NB!** By default `toggl-to-sqlite` only fetches data from the 25 previous days. As an alternative you can specify to get time_entries since a specific date. You do this by specifying the `since` option:
+
+    $ toggl-to-sqlite fetch -s 2021-03-13
+
 You can choose to get only `time_entries`, `projects`, or `workspaces` by speciying a type in the argument like this. 
 
 To get ONLY your workspaces:
@@ -40,10 +44,6 @@ To get your workspaces and projects:
     $ toggl-to-sqlite fetch -t workspaces -t projects toggl.db
 
 The default is to get all three of `time_entries`, `projects`, and `workspaces`
-
-Additionally, you can specify to get time_entries since a specific date. You do this by specifying the `since` option:
-
-    $ toggl-to-sqlite fetch -s 2021-03-13
 
 ## Using with Datasette
 

--- a/toggl_to_sqlite/cli.py
+++ b/toggl_to_sqlite/cli.py
@@ -23,7 +23,7 @@ def auth(auth):
     click.echo("Visit this page and sign in with your Toggl account:\n")
     click.echo("https://track.toggl.com/profile")
     api_token = input(
-        "Once you have signed in there, copy your API Toekn at the bottom of the page, paste it here, and press <enter>: "
+        "Once you have signed in there, copy your API Token at the bottom of the page, paste it here, and press <enter>: "
     )
     # Now exchange the request_token for an access_token
 


### PR DESCRIPTION
Great work on this small utility CLI, I have been looking for something like this for a while, being too lazy to write it myself :raised_hands: 

This PR includes two very minor improvements to the documentation I identified while playing with this:
- Fix small "API Token" typo
- Make --since=25 default option more clear

See diff for details. I specifically moved the documentation of `--since` a bit up in the README because this caught me a bit off-guard. I thought it would be nice to emphasize it a bit more.

Thanks again,
- Jakob
