### PR TITLE
Fetch both archived and active Toggl projects

### DIFF
--- a/toggl_to_sqlite/utils.py
+++ b/toggl_to_sqlite/utils.py
@@ -44,6 +44,7 @@ def get_projects(api_token):
         for workspace in workspaces[0]:
             response = requests.get(
                 f'https://api.track.toggl.com/api/v8/workspaces/{workspace["id"]}/projects',
+                params={"active": "both"},
                 auth=(api_token, "api_token"),
             )
             project = json.loads(response.text)


### PR DESCRIPTION
By default the projects API endpoint only fetches active projects. I see no reason for not fetching archived projects as well, the `projects.active` column can be used to filter instead. I have tested in manually on my end, and it works.

### Motivation
I used Toggl to track my course work during university and always archived each course project after the final exam. I would still like to analyze this data.

Again, thanks,
- Jakob
